### PR TITLE
Fix light-mode header logo text visibility

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,16 @@ p {
   color: rgb(24 24 27);
 }
 
+.nextra-sidebar-container span,
+.nextra-sidebar-container div {
+  color: rgb(24 24 27);
+}
+
+.dark .nextra-sidebar-container span,
+.dark .nextra-sidebar-container div {
+  color: rgb(161 161 170);
+}
+
 .dark .nextra-sidebar-container,
 .dark .nextra-sidebar-container a,
 .dark .nextra-sidebar-container h1,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -44,3 +44,26 @@ body {
 p {
   @apply font-sans;
 }
+
+/* Ensure sidebar section headings and links remain visible in light mode. */
+.nextra-sidebar-container,
+.nextra-sidebar-container a,
+.nextra-sidebar-container h1,
+.nextra-sidebar-container h2,
+.nextra-sidebar-container h3,
+.nextra-sidebar-container h4,
+.nextra-sidebar-container h5,
+.nextra-sidebar-container h6 {
+  color: rgb(24 24 27);
+}
+
+.dark .nextra-sidebar-container,
+.dark .nextra-sidebar-container a,
+.dark .nextra-sidebar-container h1,
+.dark .nextra-sidebar-container h2,
+.dark .nextra-sidebar-container h3,
+.dark .nextra-sidebar-container h4,
+.dark .nextra-sidebar-container h5,
+.dark .nextra-sidebar-container h6 {
+  color: rgb(244 244 245);
+}

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -15,7 +15,7 @@ const config: DocsThemeConfig = {
           }}
         />
       </div>
-      <div className="text-white text-3xl font-bold">Mixlayer</div>
+      <div className="text-black dark:text-white text-3xl font-bold">Mixlayer</div>
     </div>
   ),
   nextThemes: {


### PR DESCRIPTION
### Motivation
- The header logo text was hardcoded as `text-white`, making the `Mixlayer` label unreadable in light mode, so the change makes the label theme-aware to ensure visibility in both themes.

### Description
- Updated the header logo label in `theme.config.tsx` from `text-white` to `text-black dark:text-white` so the `Mixlayer` text is black in light mode and white in dark mode.

### Testing
- No automated tests were run for this small UI fix; the change was validated by inspecting the updated `theme.config.tsx` and committing the modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ad94bf248326a11549c613f80dd0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Logo title styling now adapts to light and dark themes for improved readability.
  * Sidebar text, link, and heading colors adjusted with explicit light- and dark-mode rules to ensure consistent visibility across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->