### PR TITLE
Follow-up: fix heading hierarchy so h3 is not larger than h2

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -79,9 +79,14 @@ select {
   line-height: 1.75rem;
 }
 
-.nextra-content :where(h3, h4, h5, h6) {
+.nextra-content h3 {
   font-size: 1rem;
   line-height: 1.5rem;
+}
+
+.nextra-content :where(h4, h5, h6) {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
 }
 
 .nextra-content :where(h1, h2, h3, h4, h5, h6)::before {


### PR DESCRIPTION
### Motivation
- Fix inconsistent heading sizing where `h3` could render larger than `h2` due to the low-specificity `:where(...)` rule in `styles/globals.css`.

### Description
- Replace `.nextra-content :where(h3, h4, h5, h6)` with an explicit `.nextra-content h3` rule and add `.nextra-content :where(h4, h5, h6)` so heading sizes consistently descend (`h2 > h3 > h4+`).

### Testing
- Ran a repository-wide search with `rg -n "h2|h3|heading|font-size"`, inspected the updated file with `nl -ba styles/globals.css`, reviewed the `git diff -- styles/globals.css` output, and validated CSS specificity via a quick web search; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a053aeb9764832688a622d808be3fb7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved heading typography styling to ensure consistent font sizing and line-height across different content heading levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mixlayer/mixlayer-docs/pull/6)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->